### PR TITLE
Minor documentation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template 
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+1.0 (Unreleased)
+````````````````
+* Ensure mock package gets installed on testing.
+
 0.9 (2014-08-02)
 ````````````````
 * First beta release

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ in each of these
 small programs both
 breaks my train of thought
 and greatly increases the
-volume of code I am writting.
+volume of code I am writing.
 
 Begins was implemented to
 remove the boilerplate code
@@ -150,7 +150,7 @@ those parameters::
 
     >>> import begin
     >>> @begin.start
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 The decorated function above
@@ -167,13 +167,13 @@ command line help::
 
    optional arguments:
      -h, --help            show this help message and exit
-     -n NAME, --name NAME  (default: Arther)
+     -n NAME, --name NAME  (default: Arthur)
      -q QUEST, --quest QUEST
                            (default: Holy Grail)
      -c COLOUR, --colour COLOUR
                            (default: blue)
 
-In Python3, any `function annotations`_
+In Python 3, any `function annotations`_
 for a parameter become
 the command line option help.
 For example::
@@ -234,7 +234,7 @@ the ``begin.start`` decorator::
 
     >>> import begin
     >>> @begin.start(short_args=False)
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 This program will not
@@ -278,7 +278,7 @@ Issues
 
 Any bug reports or
 feature requests can
-be made using GitHub' `issues system`_.
+be made using GitHub's `issues system`_.
 
 .. _Github: https://github.com/aliles/begins
 .. _Read The Docs: http://begins.readthedocs.org

--- a/docs/examples/holygrail_py2.py
+++ b/docs/examples/holygrail_py2.py
@@ -1,4 +1,4 @@
 import begin
 @begin.start
-def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     "tis but a scratch!"

--- a/docs/examples/longargs.py
+++ b/docs/examples/longargs.py
@@ -1,4 +1,4 @@
 import begin
 @begin.start(short_args=False)
-def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     "tis but a scratch!"

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -29,7 +29,7 @@ in each of these
 small programs both
 breaks my train of thought
 and greatly increases the
-volume of code I am writting.
+volume of code I am writing.
 
 Begins was implemented to
 remove the boilerplate code
@@ -150,7 +150,7 @@ those parameters::
 
     >>> import begin
     >>> @begin.start
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 The decorated function above
@@ -167,7 +167,7 @@ command line help::
 
    optional arguments:
      -h, --help            show this help message and exit
-     -n NAME, --name NAME  (default: Arther)
+     -n NAME, --name NAME  (default: Arthur)
      -q QUEST, --quest QUEST
                            (default: Holy Grail)
      -c COLOUR, --colour COLOUR
@@ -234,7 +234,7 @@ the ``begin.start`` decorator::
 
     >>> import begin
     >>> @begin.start(short_args=False)
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 This program will not
@@ -464,7 +464,7 @@ the ``env_prefix`` parameter::
 
     >>> import begin
     >>> @begin.start(env_prefix='MP_')
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 In the example above,
@@ -494,7 +494,7 @@ the ``config_file`` parameter::
 
     >>> import begin
     >>> @begin.start(config_file='.camelot.cfg')
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 This example will
@@ -517,7 +517,7 @@ parameter to ``begin.start()``::
 
     >>> import begin
     >>> @begin.start(config_file='.camelot.cfg', config_section='camelot')
-    ... def run(name='Arther', quest='Holy Grail', colour='blue', *knights):
+    ... def run(name='Arthur', quest='Holy Grail', colour='blue', *knights):
     ...     "tis but a scratch!"
 
 In this second example
@@ -852,7 +852,7 @@ Use of the ``start()`` method is
 required because the
 main function is not
 called from the ``__main__`` module
-by the entryp points system.
+by the entry points system.
 
 .. _issues:
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=requires,
-    tests_require=['mock'] + [] if PYTHON3K else ['unittest2'],
+    tests_require=['mock'] + ([] if PYTHON3K else ['unittest2']),
     test_suite="tests" if PYTHON3K else "unittest2.collector"
 )


### PR DESCRIPTION
Great library, thanks!  

A few minor documentation typo fixes.  When trying to run the tests, I noticed that mock wasn't being installed automatically due to the order of operators in `setup.py`.  Finally, adds a gitignore file (from https://github.com/github/gitignore/blob/master/Python.gitignore) for convenience.

As a side note, I noticed that much of the content is the same between the readme and the guide in the docs.  It's possible to use the rst directive `.. include :: ../README.rst` inside `docs/guide.rst` to automatically bring in content from the readme.  You'll likely have to play around with the headings to get things right in the Sphinx output, but that might help reduce the double-up.
