### PR TITLE
Remove setup/install/test boilerplate

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+test_command=OS_STDOUT_CAPTURE=1 OS_STDERR_CAPTURE=1 OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} ${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
+test_id_option=--load-list $IDFILE
+test_list_option=--list

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,7 @@ python:
   - 3.4
   - pypy
 install:
-  - pip install -r requirements.txt
-  - python setup.py install
-script:
-  - coverage run setup.py test
-  - coverage report --show-missing
-after_success:
-  - coveralls
+  - pip install tox-travis
 notifications:
     email: aaron.iles+travis-ci@gmail.com
+script: tox

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ listed in the package configuration.
 If using `Pip`_ to
 install *begins* then
 the required dependencies will
-be automatically installed.
+be automatically installed if required.
 
 ------------
 Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
+argparse; python_version=='2.6'
 bottle
 coverage
 coveralls
 pip
 flake8
 flask
-funcsigs
+funcsigs; python_version=='3.2'
+funcsigs; python_version=='2.7'
+funcsigs; python_version=='2.6'
 mock
 sphinx
 twine
 wheel
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = begins
+author = Aaron Iles
+author-email = aaron.iles@gmail.com
+summary = Command line programs for busy developers
+description-file = README.rst
+home-page = http://begins.readthedocs.org
+license = ASL
+classifier =
+        Development Status :: 4 - Beta
+        Intended Audience :: Developers
+        License :: OSI Approved :: Apache Software License
+        Operating System :: MacOS :: MacOS X
+        Operating System :: POSIX :: Linux
+        Programming Language :: Python :: 2
+        Programming Language :: Python :: 2.6
+        Programming Language :: Python :: 2.7
+        Programming Language :: Python :: 3
+        Programming Language :: Python :: 3.2
+        Programming Language :: Python :: 3.3
+        Programming Language :: Python :: 3.4
+        Programming Language :: Python :: Implementation :: CPython
+        Programming Language :: Python :: Implementation :: PyPy
+        Topic :: Software Development :: Libraries :: Python Module
+[backwards_compat]
+zip_safe = false
+[files]
+packages =
+    begins

--- a/setup.py
+++ b/setup.py
@@ -3,52 +3,11 @@ from setuptools import setup
 import re
 import sys
 
-
-def load_version(filename='begin/version.py'):
-    "Parse a __version__ number from a source file"
-    with open(filename) as source:
-        text = source.read()
-        match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", text)
-        if not match:
-            msg = "Unable to find version number in {}".format(filename)
-            raise RuntimeError(msg)
-        version = match.group(1)
-        return version
-
 PYTHON3K = sys.version_info[0] > 2
 
-requires = ['funcsigs'] if sys.version_info[:2] < (3, 3) else []
-requires += ['argparse'] if sys.version_info[:2] < (2, 7) else []
-
 setup(
-    name="begins",
-    version=load_version(),
-    packages=['begin'],
-    zip_safe=False,
-    author="Aaron Iles",
-    author_email="aaron.iles@gmail.com",
-    url="http://begins.readthedocs.org",
-    description="Command line programs for busy developers",
-    long_description=open('README.rst').read(),
-    license="ASL",
-    classifiers = [
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ],
-    install_requires=requires,
+    setup_requires=['pbr'],
+    pbr=True,
     tests_require=['mock'] + ([] if PYTHON3K else ['unittest2']),
     test_suite="tests" if PYTHON3K else "unittest2.collector"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python
 from setuptools import setup
-import re
 import sys
-
-PYTHON3K = sys.version_info[0] > 2
 
 setup(
     setup_requires=['pbr'],
     pbr=True,
-    tests_require=['mock'] + ([] if PYTHON3K else ['unittest2']),
-    test_suite="tests" if PYTHON3K else "unittest2.collector"
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,36 @@
+[tox]
+minversion = 1.6
+skipsdist = True
+envlist = py32,py33,py34,py26,py27,pypy,pep8,docs
+
+[testenv]
+usedevelop = True
+install_command = pip install testrepository {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+commands = python setup.py testr --testr-args='{posargs}'
+
+[tox:jenkins]
+sitepackages = True
+downloadcache = ~/cache/pip
+
+[testenv:pep8]
+commands = flake8 {posargs}
+
+[testenv:docs]
+commands = python setup.py build_sphinx
+
+[testenv:cover]
+setenv = VIRTUAL_ENV={envdir}
+commands =
+  python setup.py testr --coverage
+
+[testenv:venv]
+commands = {posargs}
+
+[flake8]
+# H405  multi line docstring summary not separated with an empty line
+# H904 "Wrap lines in parentheses and not a backslash for line continuation
+# Removed in current hacking (https://review.openstack.org/#/c/101701/).
+ignore = H405,H803,H904
+exclude = .venv,.tox,dist,doc,*.egg,build
+show-source = true


### PR DESCRIPTION
- Use pbr, which allows for a declarative config in setup.cfg instead of programmatic in setup.py
- Use tox and testr for running tests
- Auto-generate travis config from tox

As a result, a developer can now simply run "tox" on the local machine and test in as many python versions as they have available - and Travis will run the same tests.

pbr reads install_requires from requirements.txt, so we can add argparse and funcsigs there (protected by environment markers so that they're only installed if required)

When pbr runs it will, by default, try to autogenerate an AUTHORS file and a CHANGELOG from the git logs. This can be disabled by exporting SKIP_GENERATE_AUTHORS=1 and SKIP_WRITE_GIT_CHANGELOG=1 before running setup.py
