### PR TITLE
Fix for config_section bug with subcommands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 install:
   - pip install -r requirements.txt
+  # coverage 4 dropped support for 3.2 so we need to downgrade
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install 'coverage<4'; fi
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,6 @@ be made using GitHub's `issues system`_.
    :target: https://coveralls.io/r/aliles/begins?branch=master
    :alt: Latest PyPI version
 
-.. |pypi_version| image:: https://pypip.in/v/begins/badge.png
-   :target: https://crate.io/packages/begins/
+.. |pypi_version| image:: https://img.shields.io/pypi/v/bloscpack.svg
+   :target: https://pypi.python.org/pypi/begins
    :alt: Latest PyPI version

--- a/begin/__init__.py
+++ b/begin/__init__.py
@@ -7,7 +7,7 @@ from begin.subcommands import subcommand
 from begin.version import __version__
 
 from begin.extensions import tracebacks
-from begin.extensions import logger_old as logging
+from begin.extensions import logger_func as logging
 from begin.extensions import logger
 
 import begin.formatters

--- a/begin/__init__.py
+++ b/begin/__init__.py
@@ -7,7 +7,8 @@ from begin.subcommands import subcommand
 from begin.version import __version__
 
 from begin.extensions import tracebacks
-from begin.extensions import logger as logging
+from begin.extensions import logger_old as logging
+from begin.extensions import logger
 
 import begin.formatters
 import begin.utils

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -179,7 +179,6 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
     while hasattr(func, '__wrapped__') and not hasattr(func, '__signature__'):
         if isinstance(func, extensions.Extension):
             func.add_arguments(parser, defaults)
-            have_extensions = True
         func = getattr(func, '__wrapped__')
     funcsig = signature(func)
     populate_parser(parser, defaults, funcsig, short_args, lexical_order, double_flags)
@@ -202,7 +201,6 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             defaults.set_config_section(subfunc.__name__)
             populate_parser(subparser, defaults, funcsig, short_args,
                             lexical_order, double_flags)
-    have_extensions = False
     return parser
 
 

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -177,6 +177,7 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
     if len(collector) > 0:
         subparsers = parser.add_subparsers(title='Available subcommands',
                 dest='_subcommand')
+        subparsers.required = True
         for subfunc in collector.commands():
             funcsig  = signature(subfunc)
             help = None

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -182,7 +182,7 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             have_extensions = True
         func = getattr(func, '__wrapped__')
     funcsig = signature(func)
-    populate_parser(parser, defaults, funcsig, short_args, lexical_order)
+    populate_parser(parser, defaults, funcsig, short_args, lexical_order, double_flags)
     # Subcommands
     collector = collector if collector is not None else subcommands.COLLECTORS[sub_group]
     if plugins is not None:
@@ -203,16 +203,6 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             populate_parser(subparser, defaults, funcsig, short_args,
                             lexical_order, double_flags)
     have_extensions = False
-<<<<<<< HEAD
-=======
-    while hasattr(func, '__wrapped__') and not hasattr(func, '__signature__'):
-        if isinstance(func, extensions.Extension):
-            func.add_arguments(parser, defaults)
-            have_extensions = True
-        func = getattr(func, '__wrapped__')
-    funcsig = signature(func)
-    populate_parser(parser, defaults, funcsig, short_args, lexical_order, double_flags)
->>>>>>> 2bdaf154f4c88ca0cccbf3e72792452a73f877b3
     return parser
 
 

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -101,7 +101,7 @@ def populate_flag(parser, param, defaults, double_flags):
     if double_flags:
         parser.add_argument(('--' if default else '--no-') + param_name,
                 action='store_true' if default else 'store_false',
-                default=default, dest=param.name, help=help)
+                default=default, dest=param.name, help='')
 
 
 def populate_option(parser, param, defaults, short_args):

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -171,6 +171,15 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             description = func.__doc__,
             formatter_class=formatter_class
     )
+    # Main function
+    while hasattr(func, '__wrapped__') and not hasattr(func, '__signature__'):
+        if isinstance(func, extensions.Extension):
+            func.add_arguments(parser, defaults)
+            have_extensions = True
+        func = getattr(func, '__wrapped__')
+    funcsig = signature(func)
+    populate_parser(parser, defaults, funcsig, short_args, lexical_order)
+    # Subcommands
     collector = collector if collector is not None else subcommands.COLLECTORS[sub_group]
     if plugins is not None:
         collector.load_plugins(plugins)
@@ -188,13 +197,6 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             defaults.set_config_section(subfunc.__name__)
             populate_parser(subparser, defaults, funcsig, short_args, lexical_order)
     have_extensions = False
-    while hasattr(func, '__wrapped__') and not hasattr(func, '__signature__'):
-        if isinstance(func, extensions.Extension):
-            func.add_arguments(parser, defaults)
-            have_extensions = True
-        func = getattr(func, '__wrapped__')
-    funcsig = signature(func)
-    populate_parser(parser, defaults, funcsig, short_args, lexical_order)
     return parser
 
 

--- a/begin/extensions.py
+++ b/begin/extensions.py
@@ -113,7 +113,7 @@ class Logging(Extension):
         # formatter
         fmt = opts.logfmt
         if fmt is None:
-            if opts.logfile is None:
+            if sys.stdout.isatty() and opts.logfile is None:
                 fmt = '%(message)s'
             else:
                 fmt = '[%(asctime)s] [%(levelname)s] [%(pathname)s:%(lineno)s] %(message)s'

--- a/begin/extensions.py
+++ b/begin/extensions.py
@@ -129,6 +129,10 @@ class Logging(Extension):
         handler.setFormatter(formatter)
 
 
+def logger_old(func):
+    "Add command line extension for logging module"
+    return Logging(func)
+
 def logger(**kwargs):
     "Add command line extension for logging module"
     def decorator(func):

--- a/begin/main.py
+++ b/begin/main.py
@@ -58,22 +58,8 @@ class Program(Wrapping):
 
 
 def start(func=None, **kwargs):
-    """Return True if called in a module that is executed.
-
-    Inspects the '__name__' in the stack frame of the caller, comparing it
-    to '__main__'. Thus allowing the Python idiom:
-
-    >>> if __name__ == '__main__':
-    ...     pass
-
-    To be replace with:
-
-    >>> import begin
-    >>> if begin.start():
-    ...    pass
-
-    Can also be used as a decorator to register a function to run after the
-    module has been loaded.
+    """Decorator to register a function to run after the module has been
+    loaded.
 
     >>> @begin.start
     ... def main():
@@ -108,27 +94,19 @@ def start(func=None, **kwargs):
 
     The environment variable 'PY_FIRST' will be used instead of 'FIRST'.
     """
+
     def _start(func):
-        prog = Program(func, **kwargs)
         if func.__module__ == '__main__':
+            prog = Program(func, **kwargs)
             try:
-                prog.start()
+                sys.exit(prog.start())
             except KeyboardInterrupt:
                 sys.exit(1)
-        return prog
+        return func
 
     # start() is a decorator factory
     if func is None and len(kwargs) > 0:
         return _start
-    # start() is a boolean function
-    elif func is None:
-        stack = inspect.stack()
-        if len(stack) < 1:
-            return False
-        frame = stack[1][0]
-        if not inspect.isframe(frame):
-            return False
-        return frame.f_globals['__name__'] == '__main__'
     # not correctly used to decorate a function
     elif not callable(func):
         raise ValueError("Function '{0!r}' is not callable".format(func))

--- a/begin/main.py
+++ b/begin/main.py
@@ -58,8 +58,22 @@ class Program(Wrapping):
 
 
 def start(func=None, **kwargs):
-    """Decorator to register a function to run after the module has been
-    loaded.
+    """Return True if called in a module that is executed.
+
+    Inspects the '__name__' in the stack frame of the caller, comparing it
+    to '__main__'. Thus allowing the Python idiom:
+
+    >>> if __name__ == '__main__':
+    ...     pass
+
+    To be replace with:
+
+    >>> import begin
+    >>> if begin.start():
+    ...    pass
+
+    Can also be used as a decorator to register a function to run after the
+    module has been loaded.
 
     >>> @begin.start
     ... def main():
@@ -94,19 +108,27 @@ def start(func=None, **kwargs):
 
     The environment variable 'PY_FIRST' will be used instead of 'FIRST'.
     """
-
     def _start(func):
+        prog = Program(func, **kwargs)
         if func.__module__ == '__main__':
-            prog = Program(func, **kwargs)
             try:
-                sys.exit(prog.start())
+                prog.start()
             except KeyboardInterrupt:
                 sys.exit(1)
-        return func
+        return prog
 
     # start() is a decorator factory
     if func is None and len(kwargs) > 0:
         return _start
+    # start() is a boolean function
+    elif func is None:
+        stack = inspect.stack()
+        if len(stack) < 1:
+            return False
+        frame = stack[1][0]
+        if not inspect.isframe(frame):
+            return False
+        return frame.f_globals['__name__'] == '__main__'
     # not correctly used to decorate a function
     elif not callable(func):
         raise ValueError("Function '{0!r}' is not callable".format(func))

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -350,7 +350,7 @@ def test_keyword_only(self):
         self.opts.tracebacks = True
         self.opts.tbdir = None
         cmdline.apply_options(main, self.opts)
-        enable.assert_called_one(format='txt', logdir=None)
+        enable.assert_called_once_with(format='txt', logdir=None)
 
     def test_subcommand(self):
         @subcommands.subcommand

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -115,8 +115,8 @@ def test_positional_with_annotation(self):
     parser = cmdline.create_parser(main)
     self.assertEqual(len(parser._optionals._actions), 4)
     self.assertEqual(parser._optionals._actions[1].help, 'help string')
-    self.assertEqual(parser._optionals._actions[2].help, '')
-    self.assertTrue(parser._optionals._actions[3].help.startswith('flagged'))
+    self.assertTrue(parser._optionals._actions[2].help.startswith('flagged'))
+    self.assertEqual(parser._optionals._actions[3].help, '')
 
 def test_positional_with_annotation_and_default(self):
     def main(opt:'help string'='default'):

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -232,7 +232,7 @@ class TestStart(unittest.TestCase):
         init = mock.Mock()
         target = mock.Mock()
         try:
-            orig_argv= sys.argv
+            orig_argv = sys.argv
             sys.argv = orig_argv[:1] + ['subcmd', '--', 'subcmd', '--', 'subcmd']
             orig_name = globals()['__name__']
             globals()['__name__'] = "__main__"
@@ -247,6 +247,29 @@ class TestStart(unittest.TestCase):
         finally:
             sys.argv = orig_argv
             globals()['__name__'] = orig_name
+
+    def test_subcommand_required(self):
+        init = mock.Mock()
+        target = mock.Mock()
+        orig_name = globals()['__name__']
+        orig_argv = sys.argv
+        try:
+            sys.argv = orig_argv[:1]
+            globals()['__name__'] = '__main__'
+            with self.assertRaises(SystemExit) as _:
+                @begin.subcommand
+                def a():
+                    pass
+                @begin.subcommand
+                def b():
+                    pass
+                @begin.start
+                def main():
+                    pass
+        finally:
+            sys.argv = orig_argv
+            globals()['__name__'] = orig_name
+
 
     @mock.patch('pkg_resources.iter_entry_points')
     def test_plugins(self, iep):


### PR DESCRIPTION
Reorder code in cmdline:create_parser to correct a bug where the config_section setting was being ignored for the main function when subcommands are used. (The subcommand setup is overwriting the config section used by populate_parser, so do it after setting up the main function.)